### PR TITLE
fix: remove exec flag

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Chrysostomus @forum.manjaro.org
 pkgname=delayed-hibernation
 pkgver=0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="systemd hook to hibernate suspended system after a delay"
 arch=(any)
 url="https://github.com/Chrysostomus/$pkgname"
@@ -13,5 +13,5 @@ md5sums=('SKIP')
 
 package () {
   cd "$srcdir"
-  install -Dm755 "$srcdir/$pkgname/suspend-to-hibernate.service" "$pkgdir/etc/systemd/system/suspend-to-hibernate.service"
+  install -Dm644 "$srcdir/$pkgname/suspend-to-hibernate.service" "$pkgdir/etc/systemd/system/suspend-to-hibernate.service"
 }


### PR DESCRIPTION
Fixes:

> Configuration file /etc/systemd/system/suspend-to-hibernate.service is marked
> executable. Please remove executable permission bits.